### PR TITLE
Add SwiftPM and Github actions support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: "ComScore CI"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:          
+  Pods:
+    name: Cocoapods Lint (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod lib lint
+        run: pod lib lint --fail-fast
+          
+  SwiftPM:
+    name: SwiftPM (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable 
+
+      - name: Build
+        run: xcodebuild -scheme ComScore -destination generic/platform=iOS

--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,8 @@ FakesAssemblies/
 
 # Python
 *.pyc
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/ComScore.podspec
+++ b/ComScore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ComScore'
-  s.version          = '6.9.0'
+  s.version          = '6.10.0'
   s.summary          = 'Official analytics library for iOS and tvOS from comScore'
   s.description      = <<-DESC
   This library is used to collect analytics from iOS and tvOS applications. The library supports apps developed in native Objective C or Swift with Apple Xcode or in other languages/tools which can include and use native Objective C libraries.
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license          = 'Custom'
   s.author           = { "comScore" => "www.comscore.com" }
   s.source           = { :git => "https://github.com/comscore/ComScore-iOS-watchOS-tvOS.git", :tag => s.version.to_s }
-  s.platforms        = { :ios => "9.0", :osx => "11.0", :tvos => "9.0" }
+  s.platforms        = { :ios => "9.0", :tvos => "9.0" }
   s.libraries        = 'c++'
   s.frameworks       = 'Security'
   s.prepare_command  = <<-CMD

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "ComScore",
+    platforms: [
+        .iOS(.v9),
+        .tvOS(.v9)
+    ],
+    products: [
+        .library(
+            name: "ComScore",
+            targets: ["ComScoreDynamic"]),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "ComScoreDynamic",
+            path: "ComScore/dynamic/ComScore.xcframework"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # comScore Analytics SDK for iOS & tvOS
 
+[![CI Status](https://github.com/comScore/ComScore-iOS-watchOS-tvOS/workflows/ComScore%20CI/badge.svg?branch=master)](https://github.com/comScore/ComScore-iOS-watchOS-tvOS/actions)
 [![Version](https://img.shields.io/cocoapods/v/ComScore.svg?style=flat)](http://cocoapods.org/pods/ComScore)
 [![License](https://img.shields.io/cocoapods/l/ComScore.svg?style=flat)](http://cocoapods.org/pods/ComScore)
 [![Platform](https://img.shields.io/cocoapods/p/ComScore.svg?style=flat)](http://cocoapods.org/pods/ComScore)


### PR DESCRIPTION
* Add a SwiftPM manifest file
* Bump version to 6.10.0
* Remove `tvos` platform from podspec as it is not supported according to README and xcframework binaries. Removal should also fix the `platform` badge in the README.
* Update the .gitignore file to ignore local swiftpm artifacts
* Add Github actions for continuous integration. Actions will take into affect immediately as shown on my fork: https://github.com/master-nevi/ComScore-iOS-watchOS-tvOS/actions
* Update README badge