### PR TITLE
TAG-8492: Improve deletion of strip-framework.sh file

### DIFF
--- a/ComScore.podspec
+++ b/ComScore.podspec
@@ -14,10 +14,7 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Security'
   s.prepare_command  = <<-CMD
                          touch .pod
-                         rm -rf ComScore/dynamic/ComScore.xcframework/ios-arm64/ComScore.framework/strip-framework.sh
-                         rm -rf ComScore/dynamic/ComScore.xcframework/ios-arm64_x86_64-simulator/ComScore.framework/strip-framework.sh
-                         rm -rf ComScore/dynamic/ComScore.xcframework/tvos-arm64/ComScore.framework/strip-framework.sh
-                         rm -rf ComScore/dynamic/ComScore.xcframework/tvos-arm64_x86_64-simulator/ComScore.framework/strip-framework.sh
+                         find ComScore/dynamic/ComScore.xcframework/ -type f -name "strip-framework.sh" -delete 
                       CMD
 
   s.subspec 'Dynamic' do |ds|


### PR DESCRIPTION
In the last release the strip-framework.sh file was delivered and wasn't removed due to some path changes. This will avoid similar issues in the future